### PR TITLE
Add system start examples

### DIFF
--- a/examples/init.d/jellyfin_exporter
+++ b/examples/init.d/jellyfin_exporter
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+RETVAL=0
+PROG="jellyfin_exporter"
+EXEC="/etc/node_exporter/jellyfin_exporter"
+LOCKFILE="/var/lock/subsys/$PROG"
+OPTIONS="--web.listen-address=:9594"
+
+# Source function library.
+if [ -f /etc/rc.d/init.d/functions ]; then
+  . /etc/rc.d/init.d/functions
+else
+  echo "/etc/rc.d/init.d/functions does not exist"
+  exit 0
+fi
+
+start() {
+  if [ -f $LOCKFILE ]
+  then
+    echo "$PROG is already running!"
+  else
+    echo -n "Starting $PROG: "
+    nohup $EXEC $OPTIONS >/dev/null 2>&1 &
+    RETVAL=$?
+    [ $RETVAL -eq 0 ] && touch $LOCKFILE && success || failure
+    echo
+    return $RETVAL
+  fi
+}
+
+stop() {
+  echo -n "Stopping $PROG: "
+  killproc $EXEC
+  RETVAL=$?
+  [ $RETVAL -eq 0 ] && rm -r $LOCKFILE && success || failure
+  echo
+}
+
+restart ()
+{
+  stop
+  sleep 1
+  start
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  status)
+    status $PROG
+    ;;
+  restart)
+    restart
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+esac
+exit $RETVAL

--- a/examples/launchctl/README.md
+++ b/examples/launchctl/README.md
@@ -1,0 +1,25 @@
+# MacOS LaunchDaemon
+
+If you're installing through a package manager, you probably don't need to deal
+with this file.
+
+The `plist` file should be put in `/Library/LaunchDaemons/` (user defined daemons), and the binary installed at
+`/usr/local/bin/jellyfin_exporter`.
+
+Ex. install globally by
+
+    sudo cp -n jellyfin_exporter /usr/local/bin/
+    sudo cp -n examples/launchctl/io.prometheus.jellyfin_exporter.plist /Library/LaunchDaemons/
+    sudo launchctl bootstrap system/ /Library/LaunchDaemons/io.prometheus.jellyfin_exporter.plist
+
+    # Optionally configure by dropping CLI arguments in a file
+    echo -- '--web.listen-address=:9594' | sudo tee /usr/local/etc/jellyfin_exporter.args
+
+    # Check it's running
+    sudo launchctl list | grep jellyfin_exporter
+
+    # See full process state
+    sudo launchctl print system/io.prometheus.jellyfin_exporter
+
+    # View logs
+    sudo tail /tmp/jellyfin_exporter.log

--- a/examples/launchctl/io.prometheus.jellyfin_exporter.plist
+++ b/examples/launchctl/io.prometheus.jellyfin_exporter.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.prometheus.jellyfin_exporter</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>sh</string>
+    <string>-c</string>
+    <string>/usr/local/bin/jellyfin_exporter $(&lt; /usr/local/etc/jellyfin_exporter.args)</string>
+  </array>
+  <key>UserName</key>
+  <string>nobody</string>
+  <key>GroupName</key>
+  <string>nobody</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/jellyfin_exporter.log</string>
+  <key>StandardOutPath</key>
+  <string>/tmp/jellyfin_exporter.log</string>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+</dict>
+</plist>

--- a/examples/openbsd-rc.d/jellyfin_exporter
+++ b/examples/openbsd-rc.d/jellyfin_exporter
@@ -1,0 +1,12 @@
+#!/bin/ksh
+# Shawn Craver, 2019-04-02
+
+
+daemon="/usr/local/bin/jellyfin_exporter"
+
+. /etc/rc.d/rc.subr
+
+rc_bg=YES
+
+rc_cmd $1
+

--- a/examples/openwrt-init.d/jellyfin_exporter
+++ b/examples/openwrt-init.d/jellyfin_exporter
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+PROG="/usr/bin/jellyfin_exporter"
+OPTIONS="--web.listen-address=:9594"
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG" "${OPTIONS}"
+	procd_close_instance
+}

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -1,0 +1,6 @@
+# Systemd Unit
+
+The unit files (`*.service` and `*.socket`) in this directory are to be put into `/etc/systemd/system`.
+It needs a user named `jellyfin_exporter`, whose shell should be `/sbin/nologin` and should not have any special privileges.
+It needs a sysconfig file in `/etc/sysconfig/jellyfin_exporter`.
+A sample file can be found in `sysconfig.jellyfin_exporter`.

--- a/examples/systemd/jellyfin_exporter.service
+++ b/examples/systemd/jellyfin_exporter.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Jellyfin Exporter
+Requires=jellyfin_exporter.socket
+
+[Service]
+User=jellyfin_exporter
+EnvironmentFile=/etc/sysconfig/jellyfin_exporter
+ExecStart=/usr/sbin/jellyfin_exporter --web.systemd-socket $OPTIONS
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/jellyfin_exporter.socket
+++ b/examples/systemd/jellyfin_exporter.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=Jellyfin Exporter
+
+[Socket]
+ListenStream=9594
+
+[Install]
+WantedBy=sockets.target

--- a/examples/systemd/sysconfig.jellyfin_exporter
+++ b/examples/systemd/sysconfig.jellyfin_exporter
@@ -1,0 +1,1 @@
+OPTIONS="--jellyfin.token TOKEN"


### PR DESCRIPTION
Add a list of system start script examples. This are helpful for running the exporter as a service on your machine. 