### PR TITLE
Add activity collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,38 @@ use `--collector.disable-defaults --collector.<name> ...`.
 | users   | Exposes users and if they are currently connected. |
 
 
+### Disabled by default
+
+`jellyfin_exporter` also implements a number of collectors that
+are disabled by default.  Reasons for this vary by collector,
+and may include:
+* Plugin Required
+
+You can enable additional collectors as desired by adding them
+to your init system's or service supervisor's startup configuration
+for `jellyfin_exporter` but caution is advised. Enable at most one
+at a time, testing first on a non-production system, then by hand
+on a single production node. When enabling additional collectors,
+you should carefully monitor the change by observing the
+`scrape_duration_seconds` metric to ensure that collection completes
+and does not time out. In addition, monitor the
+`scrape_samples_post_metric_relabeling` metric to see the changes
+in cardinality.
+
+| Name     | Description                                             |
+|----------|---------------------------------------------------------|
+| activity | Exposes information from the Playback Reporting plugin. |
+
+### Activity Collector
+
+The `activity` collector can be enabled with `--collector.activity`.
+It supports exposing metrics from the Playback Reporting plugin.
+To use this collector you will need to enable the plugin first and
+edit the setting `Keep data for` and set it to `Forever`. The option
+`collector.activity.days` is set to 100 years in days by default to
+show the max amount of data. You can modify the amount of days to pull
+from, but it's recommended to leave it at its default for best data reporting.
+
 ### Filtering enabled collectors
 
 The `jellyfin_exporter` will expose all metrics from enabled collectors

--- a/collector/activity.go
+++ b/collector/activity.go
@@ -1,0 +1,85 @@
+// Copyright 2010 Rebel Media
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !noactivity
+// +build !noactivity
+
+package collector
+
+import (
+	"fmt"
+	"github.com/alecthomas/kingpin/v2"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rebelmediausa/jellyfin_exporter/collector/utils"
+	"github.com/rebelmediausa/jellyfin_exporter/config"
+)
+
+var (
+	jellyfinReportDays = kingpin.Flag("collector.activity.days", "Jellyfin Playback Reporting search in days (Default to 100 Years).").Default("36525").String()
+	activityCount      float64
+)
+
+type activityCollector struct {
+	activityReport *prometheus.Desc
+	logger         log.Logger
+}
+
+func init() {
+	registerCollector("activity", defaultDisabled, NewActivityCollector)
+}
+
+func NewActivityCollector(logger log.Logger) (Collector, error) {
+	const subsystem = "activity"
+	activityReport := prometheus.NewDesc(
+		prometheus.BuildFQName(
+			namespace, subsystem, "count",
+		),
+		"Playback Reporting activity.",
+		[]string{"user_id", "username", "last_seen", "total_time"}, nil,
+	)
+	return &activityCollector{
+		activityReport: activityReport,
+		logger:         logger,
+	}, nil
+}
+
+func (c *activityCollector) Update(ch chan<- prometheus.Metric) error {
+	jellyfinURL, jellyfinToken, nil := config.JellyfinInfo(c.logger)
+
+	jellyfinAPIURL := fmt.Sprintf("%s/user_usage_stats/user_activity?days=%s", jellyfinURL, *jellyfinReportDays)
+	rawData := utils.GetHTTP(jellyfinAPIURL, jellyfinToken)
+	data := rawData.([]interface{})
+
+	for _, item := range data {
+		activityMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		activityCount = activityMap["total_count"].(float64)
+		level.Debug(c.logger).Log("msg", "Jellyfin Playback Reporting for", "User", activityMap["user_name"].(string))
+		ch <- prometheus.MustNewConstMetric(c.activityReport,
+			prometheus.CounterValue,
+			activityCount,
+			activityMap["user_id"].(string),
+			activityMap["user_name"].(string),
+			strings.TrimSpace(activityMap["last_seen"].(string)),
+			strings.TrimSpace(activityMap["total_play_time"].(string)),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add collector to get data from the Playback Reporting Plugin. This plugin needs to be enabled for this collector to work that is why its disabled by default. 