### PR TITLE
feat(k8s): add kubernetes example of exporter deployment

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,83 @@
+# Kubernetes Deployment
+
+In case you have deployed your `jellyfin` in a kubernetes environment, the exporter can be installed as either a standalone deployment, or an extra container in your `jellyfin` deployment. This documentation provides an example of standalone exporter, using `serviceMonitor` from the `kube-prometheus-stack`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin-exporter
+  namespace: arr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jellyfin-exporter
+  template:
+    metadata:
+      labels:
+        app: jellyfin-exporter
+    spec:
+      containers:
+        - name: jellyfin-exporter
+          image: rebelcore/jellyfin-exporter:latest
+          args:
+            - "--jellyfin.address=http://jellyfin:8096"
+            - "--jellyfin.token=$(JELLYFIN_TOKEN)"
+            - "--collector.activity"
+          env:
+            - name: JELLYFIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jellyfin-api-key
+                  key: token
+          ports:
+            - containerPort: 9594
+              name: metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-exporter
+  namespace: arr
+  labels:
+    app: jellyfin-exporter
+spec:
+  selector:
+    app: jellyfin-exporter
+  ports:
+    - protocol: TCP
+      port: 9594
+      targetPort: 9594
+      name: metrics
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: jellyfin-api-key
+  namespace: arr
+data:
+  token: <your-admin-token-in-base64>
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: jellyfin-exporter
+  namespace: arr
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: jellyfin-exporter
+  namespaceSelector:
+    matchNames:
+      - arr
+  endpoints:
+    - port: metrics
+      interval: 15s
+```
+```
+```

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin-exporter
+  namespace: arr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jellyfin-exporter
+  template:
+    metadata:
+      labels:
+        app: jellyfin-exporter
+    spec:
+      containers:
+        - name: jellyfin-exporter
+          image: rebelcore/jellyfin-exporter:latest
+          args:
+            - "--jellyfin.address=http://jellyfin:8096"
+            - "--jellyfin.token=$(JELLYFIN_TOKEN)"
+            - "--collector.activity"
+          env:
+            - name: JELLYFIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jellyfin-api-key
+                  key: token
+          ports:
+            - containerPort: 9594
+              name: metrics

--- a/examples/kubernetes/kustomization.yaml
+++ b/examples/kubernetes/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+- servicemonitor.yaml
+- secret.yaml

--- a/examples/kubernetes/secret.yaml
+++ b/examples/kubernetes/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: jellyfin-api-key
+  namespace: arr
+data:
+  token: <base64-token>

--- a/examples/kubernetes/service.yaml
+++ b/examples/kubernetes/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-exporter
+  namespace: arr
+  labels:
+    app: jellyfin-exporter
+spec:
+  selector:
+    app: jellyfin-exporter
+  ports:
+    - protocol: TCP
+      port: 9594
+      targetPort: 9594
+      name: metrics
+  type: ClusterIP

--- a/examples/kubernetes/servicemonitor.yaml
+++ b/examples/kubernetes/servicemonitor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: jellyfin-exporter
+  namespace: arr
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: jellyfin-exporter
+  namespaceSelector:
+    matchNames:
+      - arr
+  endpoints:
+    - port: metrics
+      interval: 15s


### PR DESCRIPTION
I took the time to add a new example of your exporter, to be deployed in a kubernetes environment. This is the setup I quickly added to 2 of my own cluster. There is not enough metrics to share a grafana `.json` dashboard here, but if more metrics are bring to the table, I would gladly add it here