### PR TITLE
Add Grafana Dashboard repo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ services:
     restart: unless-stopped
 ```
 
+## Grafana Dashboard
+Refer to [this repository](https://github.com/rebelcore/jellyfin_grafana) to check out the official dashboard for the exporter.
+
 ## Collectors
 
 There is varying support for collectors.


### PR DESCRIPTION
Add the link to the official Grafana dashboard to be used with the exporter.

Thanks for this project. 