### PR TITLE
Add activeWithinSeconds

### DIFF
--- a/collector/playing.go
+++ b/collector/playing.go
@@ -85,7 +85,7 @@ func NewPlayingCollector(logger *slog.Logger) (Collector, error) {
 }
 
 func getNowPlayingSessions(jellyfinURL, jellyfinToken string) ([]JellyfinSession, error) {
-	jellyfinAPIURL := fmt.Sprintf("%s/Sessions?IsPlaying=true", jellyfinURL)
+	jellyfinAPIURL := fmt.Sprintf("%s/Sessions?activeWithinSeconds=60&IsPlaying=true", jellyfinURL)
 	rawData := utils.GetHTTP(jellyfinAPIURL, jellyfinToken)
 	rawBody, err := utils.CoerceToJSONBytes(rawData)
 	if err != nil {

--- a/collector/users.go
+++ b/collector/users.go
@@ -133,7 +133,7 @@ func getUserAccount(jellyfinURL, jellyfinToken string) ([]Account, error) {
 }
 
 func getUserActive(jellyfinURL, jellyfinToken string) ([]JellyfinSessionUser, error) {
-	jellyfinAPIURL := fmt.Sprintf("%s/Sessions", jellyfinURL)
+	jellyfinAPIURL := fmt.Sprintf("%s/Sessions?activeWithinSeconds=60", jellyfinURL)
 	rawData := utils.GetHTTP(jellyfinAPIURL, jellyfinToken)
 
 	rawBody, err := utils.CoerceToJSONBytes(rawData)


### PR DESCRIPTION
Add activeWithinSeconds to the sessions api call to limit the time range to check for active sessions. Jellyfin api can return sessions that are still in a active state but no one is really doing anything. This will now only return true active sessions.